### PR TITLE
feat: add blog post on git collaboration for Hugo

### DIFF
--- a/content/posts/git-collaboration-for-beginners/index.md
+++ b/content/posts/git-collaboration-for-beginners/index.md
@@ -1,0 +1,79 @@
++++
+date = '2025-06-27T15:13:35.716033+00:00'
+draft = false
+title = 'Git for Teamwork: A No-Sweat Guide to Collaboration'
+description = 'A beginner-friendly guide to using Git for collaborative software development, covering remote repositories, branching strategies, pull requests, and best practices.'
+tags = ['git', 'collaboration', 'vcs', 'tutorial', 'github', 'development']
+categories = ['technical', 'git']
++++
+
+# Git for Teamwork: A No-Sweat Guide to Working Together on Code
+
+So, you've heard about Git, maybe you've even used it a bit for your own projects. You save your work, make little notes about what you changed, and maybe even jump back to an older version when things go sideways. That's awesome! Git is a fantastic tool for keeping your coding projects organized and safe.
+
+But what happens when you're not coding alone? What if you're part of a team, all trying to build something amazing together? That's where Git really shines, but it also introduces a few new ideas. Don't worry, it's not as scary as it sounds! This guide will walk you through how to use Git with others, even if you feel like you're just starting out.
+
+## First, a Quick Recap: Git When You're Flying Solo
+
+When you're using Git by yourself, you mostly interact with your **local repository**. Think of this as your personal, super-organized project folder on your computer.
+
+*   **Commits:** You make changes to your code, and then you "commit" them. A commit is like taking a snapshot of your project at a specific point in time, along with a short message (the "commit message") explaining what you changed. (e.g., "Added a cool new button to the homepage").
+*   **Branches:** Imagine you want to try out a new idea, but you're not sure if it'll work, and you don't want to mess up your main code. You can create a "branch." A branch is like a parallel universe for your code. You can experiment freely on this branch. If it works out, you can merge it back into your main code. If not, no harm done – you can just delete the branch. Your main line of code (often called `main` or `master`) stays safe.
+
+This is great for solo work. You have a history of your changes, you can experiment safely, and you can always go back if needed.
+
+## Team Time! How Git Changes with More People
+
+When you join a team, the core ideas of Git (commits, branches) are still super important. But now, there's a new player in the game: the **remote repository**.
+
+Think of the **remote repository** (often hosted on platforms like GitHub, GitLab, or Bitbucket) as the official, shared project folder that everyone on the team can access. It's the single source of truth for your project.
+
+Here are the key new actions you'll be doing:
+
+*   **Cloning:** When you first join a project, you don't have the code yet. You'll "clone" the remote repository. This makes a complete copy of the shared project onto your computer, creating your own local repository that's linked to the remote one.
+*   **Fetching:** Your teammates are also working and making changes, pushing them to the remote repository. "Fetching" means downloading all the latest changes from the remote repository to your local machine. This *doesn't* automatically change your working files; it just updates your local Git's knowledge of what's happened remotely.
+*   **Pulling:** "Pulling" is like fetching, but it *also* tries to merge the downloaded changes into your current working branch. So, it gets the latest stuff AND tries to integrate it with what you're doing.
+*   **Pushing:** Once you've made some commits on your local machine (maybe you fixed a bug or added a new feature on a branch), you'll want to share your work with the team. "Pushing" sends your committed changes from your local repository up to the remote repository.
+
+**The Basic Team Workflow Often Looks Like This:**
+
+1.  **Pull:** Before you start working, pull the latest changes from the remote repository to make sure you have the most up-to-date version of the code. This helps avoid conflicts later.
+2.  **Create a Branch:** Don't work directly on the `main` branch! Create a new branch for the specific feature you're building or bug you're fixing (e.g., `feature/user-login` or `bugfix/fix-homepage-typo`). This keeps the main codebase stable.
+3.  **Work and Commit:** Do your coding on your new branch. Make small, logical commits with clear messages.
+4.  **Push your Branch:** Once your feature is done or you want to share your progress, push your branch to the remote repository.
+5.  **Pull Request (PR) / Merge Request (MR):** This is a crucial step! Instead of directly merging your branch into `main` on the remote, you create a "Pull Request" (GitHub/Bitbucket) or "Merge Request" (GitLab). This is a formal way of saying, "Hey team, I've finished this work, can someone please review it before we add it to the main codebase?"
+6.  **Code Review:** Your teammates can look at your changes, leave comments, ask questions, and suggest improvements. This is how teams ensure code quality and share knowledge.
+7.  **Merge:** Once your PR is approved, your branch gets merged into the `main` branch on the remote repository. Hooray! Your changes are now part of the official project.
+8.  **Repeat:** Everyone on the team keeps following this cycle.
+
+## Key Practices for Happy Collaboration
+
+Working with Git in a team is as much about communication and good habits as it is about commands. Here are some well-established practices:
+
+*   **Branching Strategy:**
+    *   **Feature Branches:** As mentioned, always create a new branch for each new piece of work (feature, bug fix, experiment). This keeps the `main` branch clean and deployable. Give your branches descriptive names (e.g., `feature/add-user-profile`, `fix/payment-gateway-error`).
+    *   **Keep `main` Sacred:** The `main` (or `master`) branch should always represent a stable, working version of your project. Only reviewed and approved code gets merged into it.
+*   **Meaningful Commit Messages:**
+    *   Write clear, concise commit messages. The first line should be a short summary (like an email subject). If you need more detail, add a blank line and then a more thorough explanation.
+    *   Explain *why* you made the change, not just *what* you changed (the code shows what you changed).
+*   **Pull Requests are Your Friends:**
+    *   Use PRs for everything that goes into `main`.
+    *   Write good PR descriptions: explain what the PR does, why it's needed, and how to test it.
+    *   Respond to review comments politely and make necessary changes.
+*   **Communicate, Communicate, Communicate:**
+    *   Talk to your teammates! If you're unsure about something, ask. If you're working on something that might affect others, let them know.
+    *   Use your project management tools (like Jira, Trello, Asana) to track tasks.
+*   **Dealing with Merge Conflicts:**
+    *   Sometimes, Git can't automatically merge changes from two different branches if they modify the same lines of code. This is a "merge conflict."
+    *   Don't panic! Git will tell you where the conflicts are. Open the conflicted files, and you'll see markers showing the different versions.
+    *   Manually edit the file to resolve the differences, choosing which version to keep or combining them. Then, commit the resolved file.
+    *   Pulling frequently helps reduce the chances and severity of merge conflicts.
+*   **Keeping Your Branches Up-to-Date:**
+    *   While you're working on your feature branch, the `main` branch might be getting updated by your teammates. It's good practice to regularly update your feature branch with the latest changes from `main`.
+    *   You can do this by **merging `main` into your branch** or by **rebasing your branch onto `main`**. Rebasing rewrites your branch's history to sit cleanly on top of `main`'s latest changes, often leading to a cleaner project history but can be tricky if you've already pushed your branch. Merging is generally safer if you're unsure. Discuss with your team what they prefer!
+
+## It Gets Easier!
+
+Using Git in a team might feel a bit clunky at first, with all the pulling, pushing, and branching. But like anything, it gets much easier with practice. The goal is to allow everyone to work productively without stepping on each other's toes, and to maintain a high-quality, understandable history of your project.
+
+Don't be afraid to ask your teammates for help. Everyone starts somewhere, and good teams support each other in learning these essential skills. Happy collaborating!


### PR DESCRIPTION
This commit adds a new blog post titled 'Git for Teamwork: A No-Sweat Guide to Collaboration'.

The post explains Git concepts for collaborative development, targeting beginners. It covers solo Git practices, introduces remote repositories, and details common workflows like feature branching, pull requests, and handling merge conflicts.

The post is structured for Hugo, including appropriate front matter with title, date, description, tags, and categories, and is placed in `content/posts/git-collaboration-for-beginners/index.md`.